### PR TITLE
NGDOC-57 #comment changed secure_link_secret from 'standard' to 'adva…

### DIFF
--- a/docs/edge-logic/supported-directives.md
+++ b/docs/edge-logic/supported-directives.md
@@ -582,7 +582,7 @@ Defines an expression for which the MD5 hash value will be computed and compared
 
 ### [`secure_link_secret`](http://nginx.org/en/docs/http/ngx_http_secure_link_module.html#secure_link_secret)
 
-<span class="badge">standard</span>
+<span class="badge dark">advanced</span>
 
 Defines a secret word used to check authenticity of requested links. No change to the public version.
 


### PR DESCRIPTION
…nced'. This was just a discrepancy in the documentation as it is on the list of advanced directives returned by the /cdn/systemConfigs API.