### PR TITLE
Updated links to point to subtopic headings

### DIFF
--- a/en/docs/portal/content-management.md
+++ b/en/docs/portal/content-management.md
@@ -29,16 +29,15 @@ If the content on your origin web server has changed, request a purge to have CD
 |----------|---------------|
 | Target Environment | Select whether the purge will occur in the staging or production environment. Default is staging.|
 | Purge Action | Select whether you want the content deleted or invalidated.  <br><ul><li><strong>Delete</strong> = removes the object from the cache of edge servers. The next time the edge server receives a request for the removed content, it retrieves the current version from your origin server. (*default*)</li><li><strong>Invalidate</strong> = this is the default setting and marks the cached content as invalid. However, the content is not removed from cache and objects are not retrieved from your origin unless they are newer than the cached versions. With this setting, CDN Pro edge servers can continue serving stale content to your end users if the origin cannot be reached.</li></ul> |
-| Purge Type | Select whether you want to purge a single file, multiple cache entries that match a wildcard, or all entries that match a regular expression. Default is file. For more information about purging using regular expressions, see [Purging Entries That Match a Regular Expression](#purgingentries) below.<br><br><strong>Note:</strong> If the file has multiple variations due to a custom cache key, select **Wildcard**.</br>|
+| Purge Type | Select whether you want to purge a single file, multiple cache entries that match a wildcard, or all entries that match a regular expression. Default is file. For more information about purging using regular expressions, see [Purging Entries That Match a Regular Expression](#purging-entries-that-match-a-regular-expression) below.<br><br><strong>Note:</strong> If the file has multiple variations due to a custom cache key, select **Wildcard**.</br>|
 | Add files to purge | If **Purge Type** is set to **File**, enter the complete URL of the file to be purged and press Enter. Repeat this step for each additional file you want to purge. If you decide not to purge a file, delete it from this field.|
 | Add a file purge header | If **Purge Type** is set to **File**, specify the name and value of the HTTP request header included in the cache key, and then click **Add Header**. Repeat this step for each additional request header you want to purge. If you decide not to purge a request header, click the **x** icon at the right side of the header name.|
-| Add directories to purge | If **Purge Type** is set to **Wildcard**, enter the complete URL of the directory you want to purge, including optional wildcards, and press Enter. Repeat this step for each additional directory you want to purge. If you decide not to purge a directory, delete it from this field. </br><br><strong>Note:</strong> Observe the following guidelines:</br><ul><li>Purging a directory also purges its subdirectories.</br></ul></li><ul><li>CDN Pro supports purging based on URL prefixes. For more information, see [Examples of Directory Purging](#dirpurging) below.</ul></li>|
+| Add directories to purge | If **Purge Type** is set to **Wildcard**, enter the complete URL of the directory you want to purge, including optional wildcards, and press Enter. Repeat this step for each additional directory you want to purge. If you decide not to purge a directory, delete it from this field. </br><br><strong>Note:</strong> Observe the following guidelines:</br><ul><li>Purging a directory also purges its subdirectories.</br></ul></li><ul><li>CDN Pro supports purging based on URL prefixes. For more information, see [Examples of Directory Purging](#examples-of-directory-purging) below.</ul></li>|
 
 4. Click **Start Purge**.
 
 **Note:** When the purge completes, a **Purge Again** button at the bottom right allows you to repeat a purge.
 
-<a id="purgingentries"></a>
 ## Purging Entries That Match a Regular Expression
 
 CDN Pro supports purges that use a regular expression (or "regex") pattern to match a cache key. The pattern must begin with <code>{scheme}: //{hostname}/</code> where <code>{scheme}</code> is http, https, or other entry that matches any scheme. For example: <br><br><code>https://test.domain.com/my.*\.(jpg|png)\?q= </code></br></br>
@@ -50,7 +49,6 @@ By default, CDN Pro allows 1,000 entries in the <code>fileUrls</code> list, 20 e
 
 **Note:** If you are a reseller, you can purge a child customer's domain. Your purge quota will apply.
 
-<a id="dirpurging"></a>
 ## Examples of Directory Purging
 
 CDN Pro allows you to purge directories by entering URLs in the <strong>Add directories to purge</strong> field. The URLs you enter can include wildcards.

--- a/zh/docs/portal/content-management.md
+++ b/zh/docs/portal/content-management.md
@@ -29,16 +29,15 @@ If the content on your origin web server has changed, request a purge to have CD
 |----------|---------------|
 | Target Environment | Select whether the purge will occur in the staging or production environment. Default is staging.|
 | Purge Action | Select whether you want the content deleted or invalidated.  <br><ul><li><strong>Delete</strong> = removes the object from the cache of edge servers. The next time the edge server receives a request for the removed content, it retrieves the current version from your origin server. (*default*)</li><li><strong>Invalidate</strong> = this is the default setting and marks the cached content as invalid. However, the content is not removed from cache and objects are not retrieved from your origin unless they are newer than the cached versions. With this setting, CDN Pro edge servers can continue serving stale content to your end users if the origin cannot be reached.</li></ul> |
-| Purge Type | Select whether you want to purge a single file, multiple cache entries that match a wildcard, or all entries that match a regular expression. Default is file. For more information about purging using regular expressions, see [Purging Entries That Match a Regular Expression](#purgingentries) below.<br><br><strong>Note:</strong> If the file has multiple variations due to a custom cache key, select **Wildcard**.</br>|
+| Purge Type | Select whether you want to purge a single file, multiple cache entries that match a wildcard, or all entries that match a regular expression. Default is file. For more information about purging using regular expressions, see [Purging Entries That Match a Regular Expression](#purging-entries-that-match-a-regular-expression) below.<br><br><strong>Note:</strong> If the file has multiple variations due to a custom cache key, select **Wildcard**.</br>|
 | Add files to purge | If **Purge Type** is set to **File**, enter the complete URL of the file to be purged and press Enter. Repeat this step for each additional file you want to purge. If you decide not to purge a file, delete it from this field.|
 | Add a file purge header | If **Purge Type** is set to **File**, specify the name and value of the HTTP request header included in the cache key, and then click **Add Header**. Repeat this step for each additional request header you want to purge. If you decide not to purge a request header, click the **x** icon at the right side of the header name.|
-| Add directories to purge | If **Purge Type** is set to **Wildcard**, enter the complete URL of the directory you want to purge, including optional wildcards, and press Enter. Repeat this step for each additional directory you want to purge. If you decide not to purge a directory, delete it from this field. </br><br><strong>Note:</strong> Observe the following guidelines:</br><ul><li>Purging a directory also purges its subdirectories.</br></ul></li><ul><li>CDN Pro supports purging based on URL prefixes. For more information, see [Examples of Directory Purging](#dirpurging) below.</ul></li>|
+| Add directories to purge | If **Purge Type** is set to **Wildcard**, enter the complete URL of the directory you want to purge, including optional wildcards, and press Enter. Repeat this step for each additional directory you want to purge. If you decide not to purge a directory, delete it from this field. </br><br><strong>Note:</strong> Observe the following guidelines:</br><ul><li>Purging a directory also purges its subdirectories.</br></ul></li><ul><li>CDN Pro supports purging based on URL prefixes. For more information, see [Examples of Directory Purging](#examples-of-directory-purging) below.</ul></li>|
 
 4. Click **Start Purge**.
 
 **Note:** When the purge completes, a **Purge Again** button at the bottom right allows you to repeat a purge.
 
-<a id="purgingentries"></a>
 ## Purging Entries That Match a Regular Expression
 
 CDN Pro supports purges that use a regular expression (or "regex") pattern to match a cache key. The pattern must begin with <code>{scheme}: //{hostname}/</code> where <code>{scheme}</code> is http, https, or other entry that matches any scheme. For example: <br><br><code>https://test.domain.com/my.*\.(jpg|png)\?q= </code></br></br>
@@ -50,7 +49,6 @@ By default, CDN Pro allows 1,000 entries in the <code>fileUrls</code> list, 20 e
 
 **Note:** If you are a reseller, you can purge a child customer's domain. Your purge quota will apply.
 
-<a id="dirpurging"></a>
 ## Examples of Directory Purging
 
 CDN Pro allows you to purge directories by entering URLs in the <strong>Add directories to purge</strong> field. The URLs you enter can include wildcards.


### PR DESCRIPTION
Burton, these fixes should point users to the children headings instead of to the line below them.