### PR TITLE
Revert "NGDOC-267 #comment updated to reinsert more changes and check on docdev"

### DIFF
--- a/en/apispec/openapi.json
+++ b/en/apispec/openapi.json
@@ -7294,8 +7294,8 @@
                   "Invalid property ID": {
                     "value": {
                       "code": "InvalidPropertyId",
-                      "message": "An invalid property ID was specified."
-                    }
+		      "message": "An invalid property ID was specified."
+                    }			
                   },
                   "Invalid status": {
                     "value": {
@@ -27659,10 +27659,7 @@
                         ]
                       },
                       "secrets": {
-                        "type": [
-                          "string",
-                          "boolean"
-                        ],
+                        "type": "string",
                         "default": true,
                         "description": "Whether the API account can access the <a href=\"#tag/Secret-Management\">secret management</a> (/cdn/secrets) endpoints. The value 'read' can be given to an operator API account to restrict it to getting the list of secrets or a secret's details.",
                         "enum": [
@@ -29948,7 +29945,7 @@
                           ],
                           "description": "another log configuration",
                           "creationTime": "2021-12-13T12:48:08Z",
-                          "lastUpdateTime": "2021-12-15T22:48:08Z"
+                          "lastUpdateTime": "2021-13-15T22:48:08Z"
                         }
                       ],
                       "count": 2
@@ -31517,7 +31514,6 @@
               "type": "string",
               "format": "date-time"
             },
-            "in": "query",
             "name": "enddate",
             "required": true,
             "description": "RFC 3339 date indicating the end of the time period. The time must be specified using the UTC timezone; it cannot be an offset. Example: <code>enddate=2019-11-14T00:00:00Z</code> Your enddate may be rounded up to the nearest minute, hour, or day depending on the <i>type</i> parameter. For example, if you enter <code>enddate=2019-09-05T03:14:01Z&type=hourly</code>, the response includes data ending 2019-09-05T04:00:00Z. Due to latency associated with new traffic data, enddate should be no later than five minutes before the current time. This ensures you get the most accurate results."
@@ -32057,7 +32053,7 @@
                   "example-1": {
                     "value": {
                       "lastUpdated": "2021-11-01T09:09:49Z",
-                      "effectiveDate": "2021-11-01T09:09:49Z",
+                      "effectiveDate": "2021-11-1T09:09:49Z",
                       "ipV4": [
                         "183.134.12.0/24",
                         "112.47.27.0/24",
@@ -33136,11 +33132,11 @@
                           },
                           "effectiveDate": {
                             "type": "string",
+                            "description": "An RFC 3339 date indicating when the shield became active.",
                             "x-stoplight": {
                               "id": "9nempgwuz9xy9"
                             },
-                            "format": "date-time",
-                            "description": "An RFC 3339 date indicating when the shield became active."
+                            "format": "date-time"
                           },
                           "usedInProperties": {
                             "type": "boolean",
@@ -33806,7 +33802,7 @@
                       "name": "my-logaggregationPoint",
                       "destinationURL": "https://ingest.customer.com/remote-log",
                       "metaData": {
-                        "creationTime": "2022-09-09T20:15:22.558+0000",
+                        "creationTime": "2022-09-09T20:15:22.558+ 0000",
                         "lastUpdateTime": "2022-09-09T20:15:22.558+0000",
                         "ingestURL": "https://codsupload.haplat.net:1443/dsp/raw?table=ngcdn_aggregation_my-logaggregationPoint"
                       }
@@ -35344,42 +35340,17 @@
             "content": {
               "application/json": {
                 "schema": {
+                  "title": "bandwidthSummaryResponse",
                   "type": "object",
-                  "x-examples": {
-                    "Example 1": {
-                      "metaData": {
-                        "startTime": "2023-07-01T00:00:00Z",
-                        "endTime": "2023-08-01T00:00:00Z",
-                        "isComplete": true,
-                        "dataNames": [
-                          "average bandwidth",
-                          "peak bandwidth",
-                          "peak bandwidth timestamp"
-                        ],
-                        "dataUnit": "megabits per second"
-                      },
-                      "groups": [
-                        {
-                          "group": "__all__",
-                          "data": [
-                            0.00698,
-                            1.78078,
-                            "2023-07-13T10:55:00Z"
-                          ]
-                        }
-                      ]
-                    }
-                  },
+                  "description": "This describes the response to the bandwidth summary report APIs.",
                   "examples": [
                     {
                       "metaData": {
-                        "startTime": "2023-07-01T00:00:00Z",
-                        "endTime": "2023-08-01T00:00:00Z",
+                        "startTime": "2021-10-01T12:35:00Z",
+                        "endTime": "2021-11-12T12:40:00Z",
                         "isComplete": true,
                         "dataNames": [
-                          "average bandwidth",
-                          "peak bandwidth",
-                          "peak bandwidth timestamp"
+                          "edge bandwidth"
                         ],
                         "dataUnit": "megabits per second"
                       },
@@ -35387,15 +35358,36 @@
                         {
                           "group": "__all__",
                           "data": [
-                            0.00698,
-                            1.78078,
-                            "2023-07-13T10:55:00Z"
+                            76763.00002
+                          ]
+                        },
+                        {
+                          "group": "hostname1.domain.info",
+                          "data": [
+                            123.00001
+                          ]
+                        },
+                        {
+                          "group": "hostname2.domain.info",
+                          "data": [
+                            67580.00001
+                          ]
+                        },
+                        {
+                          "group": "hostname3.domain.info",
+                          "data": [
+                            8720
+                          ]
+                        },
+                        {
+                          "group": "zi.domain.info",
+                          "data": [
+                            340
                           ]
                         }
                       ]
                     }
                   ],
-                  "description": "Response to the bandwidthL7Summary API",
                   "properties": {
                     "metaData": {
                       "type": "object",
@@ -35416,7 +35408,7 @@
                         },
                         "dataNames": {
                           "type": "array",
-                          "description": "Indicates the type of data returned.",
+                          "description": "Indicates the type of data returned. \"edge bandwidth\" represents edge bandwidth traffic. ",
                           "items": {
                             "type": "string"
                           }
@@ -35438,16 +35430,13 @@
                         "properties": {
                           "group": {
                             "type": "string",
-                            "description": "Name of a group. \"__all__\" is a special group encompassing all groups."
+                            "description": "Name of a group.  \"\\_\\_all\\_\\_\" is a special group encompassing all groups."
                           },
                           "data": {
                             "type": "array",
                             "description": "Data values. The units of measurement are determined by the dataUnit field.",
                             "items": {
-                              "type": [
-                                "string",
-                                "number"
-                              ]
+                              "type": "number"
                             }
                           }
                         }
@@ -35668,42 +35657,17 @@
             "content": {
               "application/json": {
                 "schema": {
+                  "title": "bandwidthSummaryResponse",
                   "type": "object",
-                  "x-examples": {
-                    "Example 1": {
-                      "metaData": {
-                        "startTime": "2023-07-01T00:00:00Z",
-                        "endTime": "2023-08-01T00:00:00Z",
-                        "isComplete": true,
-                        "dataNames": [
-                          "average bandwidth",
-                          "peak bandwidth",
-                          "peak bandwidth timestamp"
-                        ],
-                        "dataUnit": "megabits per second"
-                      },
-                      "groups": [
-                        {
-                          "group": "__all__",
-                          "data": [
-                            0.00698,
-                            1.78078,
-                            "2023-07-13T10:55:00Z"
-                          ]
-                        }
-                      ]
-                    }
-                  },
+                  "description": "This describes the response to the bandwidth summary report APIs.",
                   "examples": [
                     {
                       "metaData": {
-                        "startTime": "2023-07-01T00:00:00Z",
-                        "endTime": "2023-08-01T00:00:00Z",
+                        "startTime": "2021-10-01T12:35:00Z",
+                        "endTime": "2021-11-12T12:40:00Z",
                         "isComplete": true,
                         "dataNames": [
-                          "average bandwidth",
-                          "peak bandwidth",
-                          "peak bandwidth timestamp"
+                          "edge bandwidth"
                         ],
                         "dataUnit": "megabits per second"
                       },
@@ -35711,15 +35675,36 @@
                         {
                           "group": "__all__",
                           "data": [
-                            0.00698,
-                            1.78078,
-                            "2023-07-13T10:55:00Z"
+                            76763.00002
+                          ]
+                        },
+                        {
+                          "group": "hostname1.domain.info",
+                          "data": [
+                            123.00001
+                          ]
+                        },
+                        {
+                          "group": "hostname2.domain.info",
+                          "data": [
+                            67580.00001
+                          ]
+                        },
+                        {
+                          "group": "hostname3.domain.info",
+                          "data": [
+                            8720
+                          ]
+                        },
+                        {
+                          "group": "zi.domain.info",
+                          "data": [
+                            340
                           ]
                         }
                       ]
                     }
                   ],
-                  "description": "Response to the bandwidthL7Summary API",
                   "properties": {
                     "metaData": {
                       "type": "object",
@@ -35740,7 +35725,7 @@
                         },
                         "dataNames": {
                           "type": "array",
-                          "description": "Indicates the type of data returned.",
+                          "description": "Indicates the type of data returned. \"edge bandwidth\" represents edge bandwidth traffic. ",
                           "items": {
                             "type": "string"
                           }
@@ -35762,16 +35747,13 @@
                         "properties": {
                           "group": {
                             "type": "string",
-                            "description": "Name of a group. \"__all__\" is a special group encompassing all groups."
+                            "description": "Name of a group.  \"\\_\\_all\\_\\_\" is a special group encompassing all groups."
                           },
                           "data": {
                             "type": "array",
                             "description": "Data values. The units of measurement are determined by the dataUnit field.",
                             "items": {
-                              "type": [
-                                "string",
-                                "number"
-                              ]
+                              "type": "number"
                             }
                           }
                         }
@@ -35780,7 +35762,7 @@
                   }
                 },
                 "examples": {
-                  "Example 1": {
+                  "example-1": {
                     "value": {
                       "metaData": {
                         "startTime": "2023-07-01T00:00:00Z",


### PR DESCRIPTION
Reverts mileweb/docs-content-cdn#595
The incremental changes resulted in the return of this error opening a page like http://docdev.quantil.com/en/cdn/apidocs#operation/queryDeploymentTaskList

Unhandled Runtime Error
TypeError: displayType.split is not a function

Therefore, I want to revert and try making a smaller set of changes to isolate the problem.