### PR TITLE
ngdoc-327

### DIFF
--- a/en/docs/edge-logic/supported-directives.md
+++ b/en/docs/edge-logic/supported-directives.md
@@ -8,13 +8,13 @@ In the following list, the <span class="badge">standard</span> directives are av
 
 **Note:** Due to upgrade of the edge node structure, the Load Balancer Logic will be deprecated soon. Please avoid using this field. All supported directives should be configured in Edge Logic only. Refer to [this article](</docs/edge-logic/edge-node-structure-upgrade.md>) for more details.
 
-### `access_log_sampling`
+### `access_log_downsample`
 
-<span class="badge">standard</span> <span class="badge">LB logic</span> <span class="badge primary">proprietary</span>
+<span class="badge">standard</span> <span class="badge primary">proprietary</span>
 
-**Syntax:** `access_log_sampling factor;` <br/>
+**Syntax:** `access_log_downsample factor;` <br/>
 **Default:** `-` <br/>
-**Contexts:** server, location, if in location
+**Contexts:** server
 
 Downsamples the local access log. A `factor` of N means one log entry for every N requests. It can be used to reduce the amount of access log to download from the portal or API. A log field can be defined with the keyword `%samplerate` to show this factor. This directive has no effect on the real-time log, whose downsampling is controlled by [`realtime_log_downsample`](#realtime_log_downsample). We may also use this directive to prevent properties with large request volume from overloading the log processing system.
 
@@ -247,7 +247,7 @@ location / {
 ```
 ### [`default_type`](http://nginx.org/en/docs/http/ngx_http_core_module.html#default_type)
 
-<span class="badge">standard</span> <span class="badge">LB logic</span>
+<span class="badge">standard</span>
 
 **Syntax:** `default_type <mime-type>;`<br/>
 **Default:** `default_type application/octet-stream`<br/>
@@ -382,7 +382,7 @@ Note: Although it is currently allowed to set different MIME types for gzip and 
 
 **Syntax:** `http2_max_concurrent_streams number;` <br/>
 **Default:** `http2_max_concurrent_streams 32;` <br/>
-**Context:** server, location
+**Context:** server
 
 Sets the maximum number of concurrent HTTP/2 streams in a connection. No change to the open source version, except that the default value is set to 32.
 

--- a/zh/docs/edge-logic/supported-directives.md
+++ b/zh/docs/edge-logic/supported-directives.md
@@ -8,13 +8,13 @@
 
 **注意:** 由于边缘节点架构升级，7层负载均衡器逻辑即将被废弃。请避免使用7层负载均衡器逻辑。所有支持的指令应全部在边缘逻辑中配置。更多信息，请查看[该文档](</docs/edge-logic/edge-node-structure-upgrade.md>)。
 
-### `access_log_sampling`
+### `access_log_downsample`
 
-<span class="badge">标准</span> <span class="badge">LBLogic</span> <span class="badge primary">全新特有</span>
+<span class="badge">标准</span> <span class="badge primary">全新特有</span>
 
-**使用语法：** `access_log_sampling factor;` <br/>
+**使用语法：** `access_log_downsample factor;` <br/>
 **默认设置：** `-` <br/>
-**可用位置：** server, location, if in location
+**可用位置：** server
 
 本指令用于设置对保存访问日志进行采样的“因子”。数值 N 意味着平均每 N 个请求生产一条访问日志。它可用于减少从 Portal 或 API 下载的访问日志量。可以在日志中用 `%samplerate` 关键字记录该采样“因子”。该指令对实时日志没有影响，实时日志的采样由 [`realtime_log_downsample`](#realtime_log_downsample) 控制。在极端情况下，我们可能对某些请求量巨大的域名使用该本令来避免日志系统过载。
 
@@ -249,7 +249,7 @@ location / {
 
 ### [`default_type`](http://nginx.org/en/docs/http/ngx_http_core_module.html#default_type)
 
-<span class="badge">标准</span> <span class="badge">LBLogic</span>
+<span class="badge">标准</span>
 
 **使用语法:** `default_type <mime-type>;`<br/>
 **默认设置:** `default_type application/octet-stream`<br/>
@@ -390,7 +390,7 @@ CDN Pro 默认支持上述 MIME 类型文件（匹配不区分大小写）的 gz
 
 **使用语法：** `http2_max_concurrent_streams number;` <br/>
 **默认设置：** `http2_max_concurrent_streams 32;` <br/>
-**可用位置：** server, location
+**可用位置：** server
 
 设置单连接中HTTP/2流的最大并发数。与NGINX开源版本一致，但默认值改为32。
 


### PR DESCRIPTION
@nibinqtl @burtonquantil Please review

Note that access_log_downsample is not allowed in location and if in location, because such usage is rejected by edge logic validator. https://quantil.atlassian.net/browse/NCAS-5256?focusedCommentId=1477379
I take the chance to update http2_max_concurrent_streams to remove location from supported contexts, for the same reason.

We can make a second update, if edge logic validator is changed to allow such usage later on.