### PR TITLE
ngdoc-388: Remove two-factor authentication mention from Identity & Access overview

### DIFF
--- a/en/docs/portal/identities-and-access/overview.md
+++ b/en/docs/portal/identities-and-access/overview.md
@@ -1,6 +1,6 @@
 # About Identities and Access
 
-The Identity & Access Management page defines the users allowed to access the portal and the permissions to view and configure portal settings. It also allows you to enable two-factor authentication.
+The Identity & Access Management page defines the users allowed to access the portal and the permissions to view and configure portal settings.
 
 
 ## What are Users?


### PR DESCRIPTION
Removes the mention of two-factor authentication from the Identity & Access Management overview page.